### PR TITLE
Refactor: Member 조회 로직들 분리, Service 예외 발생

### DIFF
--- a/src/main/java/kkkw/subrandom/controller/ReviewController.java
+++ b/src/main/java/kkkw/subrandom/controller/ReviewController.java
@@ -2,11 +2,14 @@ package kkkw.subrandom.controller;
 
 import jakarta.validation.Valid;
 import kkkw.subrandom.domain.Heart;
+import kkkw.subrandom.domain.Member;
 import kkkw.subrandom.domain.Review;
+import kkkw.subrandom.domain.recipe.Recipe;
 import kkkw.subrandom.dto.ReviewCreateDto;
 import kkkw.subrandom.dto.ReviewGetDto;
 import kkkw.subrandom.repository.ReviewRepository;
 import kkkw.subrandom.service.HeartService;
+import kkkw.subrandom.service.MemberService;
 import kkkw.subrandom.service.RecipeService;
 import kkkw.subrandom.service.ReviewService;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +29,16 @@ public class ReviewController {
     private final ReviewRepository reviewRepository;
     private final ReviewService reviewService;
     private final HeartService heartService;
+    private final MemberService memberService;
 
     @PostMapping("/write")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<Review> reviewAdd(
             @Valid @RequestBody ReviewCreateDto reviewCreateDto
     ) {
-        Review review = reviewService.addMyReview(reviewCreateDto);
+        Member member = memberService.findMyMemberWithAuthorities();
+        Recipe recipe = recipeService.findRecipeByIdOrThrow(reviewCreateDto.getRecipeId());
+        Review review = reviewService.addReview(member, recipe, reviewCreateDto);
         return ResponseEntity.ok(review);
     }
 
@@ -49,7 +55,9 @@ public class ReviewController {
     @PostMapping("/heart")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<Heart> reviewAddHeart(@RequestBody Long reviewId) {
-        return ResponseEntity.ok(heartService.addMyHeart(reviewRepository.findById(reviewId).get()));
+        Member member = memberService.findMyMemberWithAuthorities();
+        Review review = reviewService.findReview(reviewId);
+        return ResponseEntity.ok(heartService.changeHeart(member, review));
     }
 
 }

--- a/src/main/java/kkkw/subrandom/controller/SaveController.java
+++ b/src/main/java/kkkw/subrandom/controller/SaveController.java
@@ -1,9 +1,11 @@
 package kkkw.subrandom.controller;
 
 import jakarta.validation.Valid;
+import kkkw.subrandom.domain.Member;
 import kkkw.subrandom.domain.Save;
 import kkkw.subrandom.domain.recipe.Recipe;
 import kkkw.subrandom.dto.RecipeCreateDto;
+import kkkw.subrandom.service.MemberService;
 import kkkw.subrandom.service.RecipeService;
 import kkkw.subrandom.service.SaveService;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class SaveController {
 
     private final RecipeService recipeService;
     private final SaveService saveService;
+    private final MemberService memberService;
 
     @PostMapping("/save")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
@@ -28,6 +31,7 @@ public class SaveController {
             @Valid @RequestBody RecipeCreateDto recipeCreateDto
     ) {
         Recipe recipe = recipeService.addRecipe(recipeCreateDto);
-        return ResponseEntity.ok(saveService.addMySave(recipe));
+        Member member = memberService.findMyMemberWithAuthorities();
+        return ResponseEntity.ok(saveService.addSave(member, recipe));
     }
 }

--- a/src/main/java/kkkw/subrandom/repository/HeartRepository.java
+++ b/src/main/java/kkkw/subrandom/repository/HeartRepository.java
@@ -4,9 +4,10 @@ import kkkw.subrandom.domain.Heart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     List<Heart> findByMemberId(Long memberId);
-    Heart findByMemberIdAndReviewId(Long memberId, Long reviewId);
+    Optional<Heart> findByMemberIdAndReviewId(Long memberId, Long reviewId);
 }

--- a/src/main/java/kkkw/subrandom/service/MemberService.java
+++ b/src/main/java/kkkw/subrandom/service/MemberService.java
@@ -4,6 +4,7 @@ package kkkw.subrandom.service;
 import kkkw.subrandom.domain.Authority;
 import kkkw.subrandom.domain.Member;
 import kkkw.subrandom.dto.MemberDto;
+import kkkw.subrandom.exceptions.MemberNotFoundException;
 import kkkw.subrandom.repository.HeartRepository;
 import kkkw.subrandom.repository.MemberRepository;
 import kkkw.subrandom.repository.ReviewRepository;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Optional;
 
 @Component
 @Transactional(readOnly = true)
@@ -29,10 +31,6 @@ public class MemberService {
     public final RecipeRepository recipeRepository;
 
     private final PasswordEncoder passwordEncoder;
-
-    public Member findMember(Long memberId){
-            return memberRepository.findById(memberId).get();
-    }
 
     @Transactional
     public Member addMember(MemberDto memberDto) {
@@ -56,12 +54,24 @@ public class MemberService {
     }
 
     public Member findMemberWithAuthorities(String email) {
-        return memberRepository.findOneWithAuthoritiesByEmail(email).orElse(null);
+        Optional<Member> optionalMember = memberRepository
+                .findOneWithAuthoritiesByEmail(email);
+
+        if (optionalMember.isEmpty()){
+            throw new MemberNotFoundException();
+        }
+
+        return optionalMember.get();
     }
 
     public Member findMyMemberWithAuthorities() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findOneWithAuthoritiesByEmail(email).orElse(null);
-    }
+        Optional<Member> optionalMember = memberRepository
+                .findOneWithAuthoritiesByEmail(SecurityUtil.getCurrentUserEmail());
 
+        if (optionalMember.isEmpty()){
+            throw new MemberNotFoundException();
+        }
+
+        return optionalMember.get();
+    }
 }

--- a/src/main/java/kkkw/subrandom/service/RecipeService.java
+++ b/src/main/java/kkkw/subrandom/service/RecipeService.java
@@ -210,16 +210,21 @@ public class RecipeService {
         return result;
     }
 
-    public Recipe findRecipe (Long recipeId) {
-        if(recipeRepository.findById(recipeId).isPresent())
-            return recipeRepository.findById(recipeId).get();
-        else throw new RecipeNotFoundException();
-    }
-
     public List<Recipe> findSavedRecipesByMemberId(Long memberId) {
 
         List<Recipe> result = new ArrayList<>();
         saveRepository.findByMemberId(memberId).forEach(s -> result.add(s.getRecipe()));
         return result;
+    }
+
+    public Recipe findRecipeByIdOrThrow(Long recipeId) {
+        Optional<Recipe> optionalRecipe = recipeRepository
+                .findById(recipeId);
+
+        if (optionalRecipe.isEmpty()){
+            throw new RecipeNotFoundException();
+        }
+
+        return optionalRecipe.get();
     }
 }

--- a/src/main/java/kkkw/subrandom/service/ReviewService.java
+++ b/src/main/java/kkkw/subrandom/service/ReviewService.java
@@ -1,15 +1,14 @@
 package kkkw.subrandom.service;
 
 
+import kkkw.subrandom.domain.Member;
 import kkkw.subrandom.domain.Review;
+import kkkw.subrandom.domain.recipe.Recipe;
 import kkkw.subrandom.dto.ReviewCreateDto;
 import kkkw.subrandom.exceptions.HeartNotFoundException;
 import kkkw.subrandom.exceptions.ReviewNotFoundException;
 import kkkw.subrandom.repository.HeartRepository;
-import kkkw.subrandom.repository.MemberRepository;
 import kkkw.subrandom.repository.ReviewRepository;
-import kkkw.subrandom.repository.recipe.RecipeRepository;
-import kkkw.subrandom.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,14 +24,12 @@ public class ReviewService {
 
     public final ReviewRepository reviewRepository;
     public final HeartRepository heartRepository;
-    public final MemberRepository memberRepository;
-    private final RecipeRepository recipeRepository;
 
     @Transactional
-    public Review addMyReview(ReviewCreateDto reviewCreateDto) {
+    public Review addReview(Member member, Recipe recipe, ReviewCreateDto reviewCreateDto) {
         Review review = Review.builder()
-                .member(memberRepository.findOneWithAuthoritiesByEmail(SecurityUtil.getCurrentUserEmail()).get())
-                .recipe(recipeRepository.findById(reviewCreateDto.getRecipeId()).get())
+                .member(member)
+                .recipe(recipe)
                 .score(reviewCreateDto.getScore())
                 .comment(reviewCreateDto.getComment())
                 .heartCounts(0L)
@@ -40,10 +37,6 @@ public class ReviewService {
                 .build();
         return reviewRepository.save(review);
     }
-
-//    public List<Review> findReviews() {
-//        return reviewRepository.findAll();
-//    }
 
     public Review findReview(Long reviewId) {
         if(reviewRepository.findById(reviewId).isPresent())

--- a/src/main/java/kkkw/subrandom/service/SaveService.java
+++ b/src/main/java/kkkw/subrandom/service/SaveService.java
@@ -1,12 +1,10 @@
 package kkkw.subrandom.service;
 
+import kkkw.subrandom.domain.Member;
 import kkkw.subrandom.domain.Save;
 import kkkw.subrandom.domain.recipe.Recipe;
 import kkkw.subrandom.exceptions.SaveNotFoundException;
-import kkkw.subrandom.repository.MemberRepository;
 import kkkw.subrandom.repository.SaveRepository;
-import kkkw.subrandom.repository.recipe.RecipeRepository;
-import kkkw.subrandom.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,13 +16,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SaveService {
 
-    private final MemberRepository memberRepository;
     private final SaveRepository saveRepository;
 
     @Transactional
-    public Save addMySave(Recipe recipe) {
+    public Save addSave(Member member, Recipe recipe) {
         Save save = Save.builder()
-                .member(memberRepository.findOneWithAuthoritiesByEmail(SecurityUtil.getCurrentUserEmail()).get())
+                .member(member)
                 .recipe(recipe)
                 .build();
         return saveRepository.save(save);


### PR DESCRIPTION
1. HeartService, ReviewService, SaveService의 ...my... 메서드들 내부의 멤버 조회 로직 제거하고 Controll단에서 멤버 조회 후 param로 사용

2. Service단 예외 발생 완료